### PR TITLE
Update novena-hook.sh

### DIFF
--- a/etc/initramfs-tools/hooks/novena.hook.sh
+++ b/etc/initramfs-tools/hooks/novena.hook.sh
@@ -23,7 +23,7 @@ esac
 
 #mkdir $DESTDIR/lib/firmware
 cp -r /lib/firmware $DESTDIR/lib/
-cp -r /lib/modules/3.19* $DESTDIR/lib/modules/
-rm -rf $DESTDIR/lib/modules/3.19*/build/
+cp -r /lib/modules/$1 $DESTDIR/lib/modules/
+rm -rf $DESTDIR/lib/modules/$1/build/
 
 #/bin/bash


### PR DESCRIPTION
This changes allows the hook to be compatible with any Linux version (not just 3.19)
